### PR TITLE
Fixed missing references in load-subfile.js

### DIFF
--- a/lib/load-subfile.js
+++ b/lib/load-subfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var hutil = require('./hub-util');
 var addSubtask = require('./add-subtask');
+var path = require('path');
 
 /**
  * Load the tasks from the specified gulpfile and register them with the task
@@ -40,7 +41,7 @@ module.exports = function(subfile, tasks) {
 };
 
 // I see trouble ahead...
-function addLocalGulpTasks(subfile, submodule) {
+function addLocalGulpTasks(subfile, submodule, tasks) {
 
     submodule.children.forEach(function(mod) {
 


### PR DESCRIPTION
load-subfile.js seemd to be broken in the latest version, gave me the following errors:
ReferenceError: path is not defined
    at /Users/simonihmig/Projects/bsp/node_modules/gulp-hub/lib/load-subfile.js:48:13
...
and
ReferenceError: tasks is not defined
    at /Users/simonihmig/Projects/bsp/node_modules/gulp-hub/lib/load-subfile.js:58:41

This should fix it!
