### PR TITLE
Correctly pass through callback parameter of task function to subtasks

### DIFF
--- a/lib/add-subtask.js
+++ b/lib/add-subtask.js
@@ -81,10 +81,10 @@ module.exports = function(subfile, tasks, name, param1, param2) {
         subparam1 = param1.map(function (dep) { return subfile.uniqueName + '-' + dep; });
 
         if (param2) {
-            subparam2 = function() {
+            subparam2 = function(cb) {
                 // give the task function the correct working directory
                 process.chdir(path.dirname(subfile.absolutePath));
-                return param2();
+                return param2(cb);
             };
         }
         else {
@@ -92,10 +92,10 @@ module.exports = function(subfile, tasks, name, param1, param2) {
         }
     }
     else {
-        subparam1 = function() {
+        subparam1 = function(cb) {
             // give the task function the correct working directory
             process.chdir(path.dirname(subfile.absolutePath));
-            return param1();
+            return param1(cb);
         };
         subparam2 = undefined;
     }

--- a/lib/add-task.js
+++ b/lib/add-task.js
@@ -16,7 +16,9 @@ module.exports = function(task) {
     var args = task.subtasks.map(function (subtask) { return subtask.name; });
 
     // create the master task which will run all the subtasks in sequence
-    gulp.task(task.name, function() {
-        runSequence.apply(null, args);
+    gulp.task(task.name, function(cb) {
+        var _args = args.slice();
+        _args.push(cb);
+        runSequence.apply(null, _args);
     });
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "glob": "^4.0.2",
     "gulp": "^3.5.5",
     "gulp-util": "^2.2.16",
-    "run-sequence": "^0.3.6",
+    "run-sequence": "^1.0.2",
     "lodash": "^2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Given a sub task expecting a callback function to signal task completion such as:

``` javascript
gulp.task('foo-bar', function(cb) {
    doSomethingAsynchronous(cb);
});
```

This works when gulp is called form the subfolder, but when called from gulp-hub this will fail as the callback function cb is always undefined. This PR fixes it, passing through the callback function from its task definitions.
