### PR TITLE
Fix for wrong subtask function signature

### DIFF
--- a/examples/project2/gulpfile.js
+++ b/examples/project2/gulpfile.js
@@ -1,12 +1,14 @@
 // this will use a private gulp instance
 var gulp = require('gulp');
 
-gulp.task('dependency', function() {
-	console.log('running project2 dependency')
+gulp.task('dependency', function(cb) {
+	console.log('running project2 dependency');
+    cb();
 });
 
-gulp.task('compile', [ 'dependency' ], function() {
-	console.log('compiling project2')
+gulp.task('compile', [ 'dependency' ], function(cb) {
+	console.log('compiling project2');
+    cb();
 });
  
 gulp.task('watch', function() {

--- a/lib/add-subtask.js
+++ b/lib/add-subtask.js
@@ -2,6 +2,23 @@ var path  = require('path');
 var _     = require( 'lodash' );
 var hutil = require('./hub-util');
 
+var makeSubtaskFunction = function(subfile, subfn) {
+    if (subfn.length > 0) {
+        // subfn is asynchronous (has callback parameter)
+        return function(cb) {
+            // give the task function the correct working directory
+            process.chdir(path.dirname(subfile.absolutePath));
+            return subfn(cb);
+        };
+    }
+    // subfn is synchronous (no callback parameter)
+    return function() {
+        // give the task function the correct working directory
+        process.chdir(path.dirname(subfile.absolutePath));
+        return subfn();
+    };
+};
+
 /**
  * Adds a subfile's tasks, task dependencies, and callback to the task registry
  * under the master task name, e.g., given a task name `task-name`, and a
@@ -81,22 +98,14 @@ module.exports = function(subfile, tasks, name, param1, param2) {
         subparam1 = param1.map(function (dep) { return subfile.uniqueName + '-' + dep; });
 
         if (param2) {
-            subparam2 = function(cb) {
-                // give the task function the correct working directory
-                process.chdir(path.dirname(subfile.absolutePath));
-                return param2(cb);
-            };
+            subparam2 = makeSubtaskFunction(subfile, param2);
         }
         else {
             subparam2 = undefined;
         }
     }
     else {
-        subparam1 = function(cb) {
-            // give the task function the correct working directory
-            process.chdir(path.dirname(subfile.absolutePath));
-            return param1(cb);
-        };
+        subparam1 = makeSubtaskFunction(subfile, param1);
         subparam2 = undefined;
     }
 


### PR DESCRIPTION
Fixes bug introduced in https://github.com/frankwallis/gulp-hub/pull/10: Changes generated subtask function signature to only include callback parameter if actual subtask has one either.

Orchestrator checks task function signature, and if callback parameter is present but never called, that task will never finish. This could be seen in the examples. Sorry about that! :-(
