### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "gulp test"
   },
   "peerDependencies": {
-    "gulp": "^4.0.0"
+    "gulp": "^4.0.0-alpha.1"
   },
   "dependencies": {
     "callsite": "^1.0.0",


### PR DESCRIPTION
Gulp 4.0 has not been released yet. NPM 2.0 fails to install the packages, with the following error message:

npm ERR! notarget No compatible version found: gulp@'>=4.0.0 <5.0.0'
npm ERR! notarget Valid install targets:
npm ERR! notarget ["0.0.1","0.0.2","0.0.3","0.0.4","0.0.5","0.0.7","0.0.8","0.
9","0.1.0","0.2.0","1.0.0","1.1.0","1.2.0","1.2.1","2.0.0","2.0.1","2.1.0","2.
0","2.3.0","2.4.0","2.4.1","2.6.0","2.6.1","2.7.0","3.0.0","3.1.1","3.1.2","3.
3","3.1.4","3.2.0","3.2.1","3.2.2","3.2.3","3.2.4","3.2.5","3.3.0","3.3.1","3.
2","3.3.4","3.4.0","3.5.0","3.5.1","3.5.2","3.5.5","3.5.6","3.6.0","3.6.1","3.
2","3.7.0","3.8.0","3.8.1","3.8.2","3.8.3","3.8.4","3.8.5","3.8.6","3.8.7","3.
8","3.8.9","3.8.10","3.8.11"]