### PR TITLE
cleanup based on undertaker init lifecycle

### DIFF
--- a/examples/forward/gulpfile.js
+++ b/examples/forward/gulpfile.js
@@ -1,14 +1,10 @@
 var gulp = require('gulp');
 
-var FwdRef = require('undertaker-forward-reference');
 var Hub = require('../../');
-
-//gulp.registry(new FwdRef());
 
 gulp.registry(new Hub(['./gulpfile2.js']));
 
-//gulp.task('default', gulp.series('forward-ref', 'forward-ref2'));
-gulp.task('default', gulp.series('forward-ref'));
+gulp.task('default', gulp.series('forward-ref', 'forward-ref2'));
 
 gulp.task('forward-ref', function(cb){
 	// do task things

--- a/lib/hub-registry.js
+++ b/lib/hub-registry.js
@@ -9,11 +9,9 @@ var path = require('path');
 var util = require('util');
 
 var _ = require('lodash');
-var gulp = require('gulp');
 var gutil = require('gulp-util');
 
-var DefaultRegistry = require('undertaker-registry');
-//var ForwardRegistry = require('undertaker-forward-reference');
+var ForwardRegistry = require('undertaker-forward-reference');
 
 var resolveGlob = require('./resolve-glob');
 var loadSubfile = require('./load-subfile');
@@ -23,28 +21,19 @@ function HubRegistry(pattern) {
 	if (!(this instanceof HubRegistry))
 		return new HubRegistry(pattern);
 
-   //ForwardRegistry.call(this);
-   DefaultRegistry.call(this);
+	ForwardRegistry.call(this);
 
 	this._registry = {};
 	this._callsite = this.getCallSite();
 
 	// resolve the list of gulpfiles
-	var gulpfiles = resolveGlob(pattern, path.dirname(this._callsite));
-
-	// load the subfiles into the registry map
-	var self = this;
-	gulpfiles.forEach(function(gulpfile) {
-		gutil.log('Loading', gutil.colors.yellow(gulpfile));
-		self._registry[gulpfile] = loadSubfile(gulpfile);
-	});
+	this._gulpfiles = resolveGlob(pattern, path.dirname(this._callsite));
 
 	// setup an internal subfile in case tasks are added from the existing registry
-	this._registry[this._callsite] = new DefaultRegistry();
+	this._registry[this._callsite] = new ForwardRegistry();
 }
 
-//util.inherits(HubRegistry, ForwardRegistry);
-util.inherits(HubRegistry, DefaultRegistry);
+util.inherits(HubRegistry, ForwardRegistry);
 
 /**
  * Get the directory of the file which gulp-hub was called from
@@ -57,9 +46,17 @@ HubRegistry.prototype.getCallSite = function() {
 }
 
 /**
- * Generate our tasks from all the subfile registries
+ * Registry API
+ * Initalise the registry
  */
-HubRegistry.prototype.getTasks = function(taker) {
+HubRegistry.prototype.init = function (gulp) {
+	// load the subfiles into the registry map
+	var self = this;
+	_.each(this._gulpfiles, function(gulpfile) {
+		gutil.log('Loading', gutil.colors.yellow(gulpfile));
+		self._registry[gulpfile] = loadSubfile(gulp, gulpfile);
+	});
+
 	var master = {};
 	var sandboxedGulp = new gulp.Gulp();
 
@@ -75,7 +72,7 @@ HubRegistry.prototype.getTasks = function(taker) {
 			sandboxedGulp.task(subname, subtask);
 
 			// retrieve the taskWrapper
-			var newtask = sandboxedGulp.registry().get(subname, subtask);
+			var newtask = sandboxedGulp.registry().get(subname);
 
 			// add it to the list of functions the master task will call
 			if (master[name])
@@ -95,28 +92,8 @@ HubRegistry.prototype.getTasks = function(taker) {
 			sandboxedGulp.task(name, gulp.series(subtasks));
 	})
 
-	return sandboxedGulp.registry().tasks();
+	this._tasks = sandboxedGulp.registry().tasks();
 };
-
-
-/**
- * Registry API
- * Initalise the registry
- */
-HubRegistry.prototype.init = function (taker) {
-	this._tasks = this.getTasks();
-};
-
-/**
- * Registry API
- * Get a registered task
- *
- * @param {string} name - the name of the task
- * @returns {function} fn - the task function
- */
-//HubRegistry.prototype.get = function (name) {
-//	return this.tasks()[name];
-//};
 
 /**
  * Registry API
@@ -126,18 +103,9 @@ HubRegistry.prototype.init = function (taker) {
  * @param {function} fn - the task function
  */
 HubRegistry.prototype.set = function (name, fn) {
+	// TODO: what if this collides with a master task?
+	ForwardRegistry.prototype.set.call(this, name, fn);
 	this._registry[this._callsite].set(name, fn);
 };
-
-/**
- * Registry API
- * Returns a new map containing all of the registered tasks
- *
- * @returns  {object} tasks - A map of the tasks
- */
-//HubRegistry.prototype.tasks = function () {
-//	return this.getTasks();
-//};
-
 
 module.exports = HubRegistry;

--- a/lib/load-subfile.js
+++ b/lib/load-subfile.js
@@ -6,7 +6,6 @@
  * Licensed under the MIT license.
  */
 var Module = require('module');
-var gulp = require('gulp');
 var fwd = require('fwd');
 
 /**
@@ -15,7 +14,7 @@ var fwd = require('fwd');
  * @param {string} path - the path of the subfile
  * @returns {object} registry - The registry of tasks created by the loaded gulpfile
  */
-module.exports = function(subfile) {
+module.exports = function(gulp, subfile) {
    var originalLoader = Module._load;
    var sandboxedGulp = new gulp.Gulp();
 
@@ -34,8 +33,8 @@ module.exports = function(subfile) {
    Module._load = originalLoader;
 
    // forward emmited events to the parent gulp instance
-   // this ensures that events emitted by gulp.series and 
-   // gulp.parallel are handled 
+   // this ensures that events emitted by gulp.series and
+   // gulp.parallel are handled
    fwd(sandboxedGulp, gulp);
 
    // return the registry of tasks just loaded

--- a/package.json
+++ b/package.json
@@ -32,16 +32,17 @@
     "glob": "^5.0.3",
     "gulp-util": "^3.0.2",
     "lodash": "^3.5.0",
-    "undertaker-registry": "0.0.3"
+    "undertaker-forward-reference": "^0.1.0"
   },
   "devDependencies": {
-    "gulp": "frankwallis/gulp#registry-init",
+    "gulp": "gulpjs/gulp#4.0",
     "gulp-istanbul": "^0.6.0",
     "gulp-mocha": "^2.0.0",
     "mocha": "^2.2.1",
     "proxyquire": "^1.4.0",
     "should": "^4.0.4",
-    "sinon": "^1.14.0"
+    "sinon": "^1.14.0",
+    "undertaker-registry": "0.0.3"
   },
   "keywords": [
     "gulp",
@@ -49,6 +50,8 @@
     "grunt-hub",
     "gulp-chug",
     "multi",
-    "gulpplugin"
+    "gulpregistry",
+    "glob",
+    "forward reference"
   ]
 }

--- a/test/load-subfile-spec.js
+++ b/test/load-subfile-spec.js
@@ -8,7 +8,7 @@ describe( 'load-subfile', function () {
    it( 'loads the registry and uses a different gulp instance', function () {
       gulp.__hubTest = false;
       var pathname = "./fixtures/gulpfile.js";
-      var registry = loadSubfile(require.resolve(pathname));
+      var registry = loadSubfile(gulp, require.resolve(pathname));
       Object.keys(registry.tasks()).length.should.be.equal(2);
       gulp.__hubTest.should.be.false; // this is set by the gulpfile
    });


### PR DESCRIPTION
I've done a bunch of cleanup related to the `init` lifecycle hook introduced into undertaker.  Mostly, I switched usage of the DefaultRegistry to the ForwardReferenceRegistry and removed the dependency on because you have access to the instance inside the `init` method, where most of the logic for this module now exists within.  I also updated the tests to reflect the `init` changes.

Ref #24