### PR TITLE
chore(pkg): change gulpplugin to gulpfriendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "grunt-hub",
     "gulp-chug",
     "multi",
-    "gulpplugin"
+    "gulpfriendly"
   ]
 }


### PR DESCRIPTION
https://github.com/gulpjs/gulp/issues/1058
https://github.com/gulpjs/gulp/tree/master/docs/writing-a-plugin
Because this module doesn't return a stream but is made for use with gulp, it should be gulpfriendly.

Also https://github.com/gulpjs/gulp/blob/master/docs/writing-a-plugin/guidelines.md
```
Name your plugin appropriately: it should begin with "gulp-" if it is a gulp plugin
If it is not a gulp plugin, it should not begin with "gulp-"
```
It should probably use a different name.