### PR TITLE
fix overwrapping of tasks

### DIFF
--- a/examples/project1/project1A/gulpfile.js
+++ b/examples/project1/project1A/gulpfile.js
@@ -6,6 +6,11 @@ function precompile1A(cb) {
 	gutil.log('precompiling project1A');
 	cb();
 };
+precompile1A.description = 'Precompiling project1A';
+precompile1A.flags = {
+    '--prod': 'Precompiling in production mode (minification, etc).',
+    '--dev': 'Precompiling in development mode.'
+};
 
 function compile1A(cb) {
 	gutil.log('compiling project1A')

--- a/lib/hub-registry.js
+++ b/lib/hub-registry.js
@@ -68,14 +68,14 @@ HubRegistry.prototype.init = function (gulp) {
 			var subname = subfileName + '-' + name;
 
 			// create the gulp task
-			sandboxedGulp.task(subname, subtask);
+			sandboxedGulp.task(subname, subtask.unwrap());
 
 			// retrieve the taskWrapper
-			var newtask = sandboxedGulp.registry().get(subname);
+			var newtask = sandboxedGulp.registry().get(subname).unwrap();
 
 			// add it to the list of functions the master task will call
 			if (master[name])
-				master[name].push(newtask)
+				master[name].push(newtask);
 			else
 				master[name] = [ newtask ];
 		});

--- a/test/example-test.js
+++ b/test/example-test.js
@@ -79,4 +79,14 @@ describe('Examples', function () {
       _.keys(gulp.registry().tasks()).should.containEql('mytesttask2');
    });
 
+    it('checks that task description and flags are correctly set', function () {
+        var hub = new HubRegistry(['../examples/gulpfile.js']);
+        hub.init(require('gulp'));
+        var project1ATask = hub.tasks().precompile1A.unwrap();
+
+        _.keys(project1ATask).length.should.be.equal(2);
+        _.keys(project1ATask).should.containEql('description');
+        _.keys(project1ATask).should.containEql('flags');
+    });
+
 });


### PR DESCRIPTION
Hello,

I will try to explain what is the issue that I want to solve. I will try to explain all the process (probably mostly for myself, because it is the first time that I touch the gulp ecosystem).
I am using gulp#4.0 and gulp-hub#4.0.

### Introduction
First, we have to understand what happen when we create a gulp task.
When we create a task in gulp. For instance:
```javascript
gulp.task("build", build);
```
1. Gulp will call [Undertaker.task](https://github.com/gulpjs/gulp/blob/e9e5ab7e70080e1bfb5650a4fdc4c8849e70b3e0/index.js#L13).
1. Undertaker.task call [Undertaker._setTask](https://github.com/gulpjs/undertaker/blob/e2b2869b7ae941c50d9bc01dc98310d0ed1fc57e/lib/task.js#L13) 
1. Then _setTask will [wrap the `build` function](https://github.com/gulpjs/undertaker/blob/e2b2869b7ae941c50d9bc01dc98310d0ed1fc57e/lib/set-task.js#L13) as _taskWrapper_

## Issue
The issue is that when you do [this](https://github.com/frankwallis/gulp-hub/blob/13f44015242393fe5b79b74ff44c75b50c0d9a4a/lib/hub-registry.js#L71), [this](https://github.com/frankwallis/gulp-hub/blob/13f44015242393fe5b79b74ff44c75b50c0d9a4a/lib/hub-registry.js#L89), or [this](https://github.com/frankwallis/gulp-hub/blob/13f44015242393fe5b79b74ff44c75b50c0d9a4a/lib/hub-registry.js#L91), you will wrap a _taskWrapper_.

### Why this is an issue ?
When we call 'gulp --tasks', it will call the `unwrap` method of _taskWrapper_ in order to retrieve the [description](https://github.com/gulpjs/gulp-cli/blob/51b301a043bd5617465fbb73ced86bf2c35a1924/lib/versioned/%5E4.0.0/log/getTask.js#L22) field and the [flags](https://github.com/gulpjs/gulp-cli/blob/51b301a043bd5617465fbb73ced86bf2c35a1924/lib/versioned/%5E4.0.0/log/getTask.js#L22) field.

Hence, if the `unwrap` return a _taskWrapper_ instead of a the task function, 'gulp --tasks' will not work currently (i.e. missing description and flags).

## Solution

The solution is to unwrap tasks when we use/retrieve them. 

```javascript
_each(subtasks, function(subtask, name) { 
   var subname = subfileName + '-' + name;

   // create the gulp task
   sandboxedGulp.task(subname, subtask.unwrap());

   // retrieve the taskWrapper
   var newtask = sandboxedGulp.registry().get(subname).unwrap();

   // add it to the list of functions the master task will call
   if (master[name])
      master[name].push(newtask);
   else
      master[name] = [ newtask ];
});
```

Thank you very much for your work.

Edit: Actually this fix is also valid for the registry-init branch.