### PR TITLE
Use gulplog instead of fancy-log in order to respect --silent gulp's argument

### DIFF
--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -5,7 +5,7 @@
 	examples> gulp exampleTask
 */
 var gulp = require('gulp');
-var gutil = require('gulp-util');
+var gutil = require('../lib/gutil');
 var HubRegistry = require('../');
 
 function precompile(cb) {

--- a/examples/project1/gulpfile.js
+++ b/examples/project1/gulpfile.js
@@ -1,6 +1,6 @@
 //var hub = require('../../lib/index.js');
 var gulp = require('gulp');
-var gutil = require('gulp-util');
+var gutil = require('../../lib/gutil');
 var HubRegistry = require('../../lib/');
 
 function precompile(cb) {

--- a/examples/project1/project1A/gulpfile.js
+++ b/examples/project1/project1A/gulpfile.js
@@ -1,6 +1,6 @@
 // this will use a private gulp instance
 var gulp = require('gulp');
-var gutil = require('gulp-util');
+var gutil = require('../../../lib/gutil');
 
 function precompile1A(cb) {
 	gutil.log('precompiling project1A');

--- a/examples/project1/project1B/gulpfile.js
+++ b/examples/project1/project1B/gulpfile.js
@@ -1,6 +1,6 @@
 // this will use a private gulp instance
 var gulp = require('gulp');
-var gutil = require('gulp-util');
+var gutil = require('../../../lib/gutil');
 
 function precompile1B(cb) {
 	gutil.log('precompiling project1B')

--- a/examples/project2/gulpfile.js
+++ b/examples/project2/gulpfile.js
@@ -1,6 +1,6 @@
 // this will use a private gulp instance
 var gulp = require('gulp');
-var gutil = require('gulp-util');
+var gutil = require('../../lib/gutil');
 
 function precompile2(cb) {
 	gutil.log('precompiling project2')

--- a/examples/recipe/tasks/dev.js
+++ b/examples/recipe/tasks/dev.js
@@ -1,5 +1,5 @@
 var gulp = require('gulp');
-var gutil = require('gulp-util');
+var gutil = require('../../../lib/gutil');
 
 function bundle(cb) {
 	gutil.log('bundling project2')

--- a/examples/recipe/tasks/release.js
+++ b/examples/recipe/tasks/release.js
@@ -1,5 +1,5 @@
 var gulp = require('gulp');
-var gutil = require('gulp-util');
+var gutil = require('../../../lib/gutil');
 
 function bump(cb) {
 	gutil.log('bumping project2')

--- a/examples/recipe/tasks/test.js
+++ b/examples/recipe/tasks/test.js
@@ -1,5 +1,5 @@
 var gulp = require('gulp');
-var gutil = require('gulp-util');
+var gutil = require('../../../lib/gutil');
 
 function e2e(cb) {
 	gutil.log('running e2e-tests')

--- a/lib/gutil.js
+++ b/lib/gutil.js
@@ -1,4 +1,9 @@
-var log = require('fancy-log');
+var log = require('gulplog');
 var colors = require('ansi-colors');
 
-module.exports = { log, colors };
+module.exports = {
+  log: function() {
+    log.info.apply(log, arguments);
+  },
+  colors: colors
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "undertaker-forward-reference": "^1.0.0"
   },
   "devDependencies": {
-    "gulp": "gulpjs/gulp#4.0",
+    "gulp": "gulpjs/gulp",
     "gulp-istanbul": "^1.1.1",
     "gulp-mocha": "^5.0.0",
     "lodash": "^4.0.0",

--- a/test/hub-registry-spec.js
+++ b/test/hub-registry-spec.js
@@ -15,7 +15,7 @@ var HAPPY_PROXY_DEPS = {
    '_': _,
    'path': path,
    'undertaker-registry': DefaultRegistry,
-   'gulp-util': {
+   './gutil': {
       log:    _.noop,
       colors: { yellow: _.noop }
    },
@@ -50,7 +50,7 @@ describe( 'HubRegistry', function () {
       var colorSpy = sinon.spy( function ( s ) { return 'yellow-' + s } );
 
       var HubRegistry = getHubRegistry( {
-         'gulp-util': {
+         './gutil': {
             log:    logSpy,
             colors: { yellow: colorSpy }
          },


### PR DESCRIPTION
Hello,

I found out that when I try to run gulp in silent mode gulp-hub is not silent.
I am using gulp (v4) and gulp-hub#4.0.

In order to fix it, I had to replace **fancy-log** by **gulplog**. **gulplog** will rely on the same logger as gulp.
So when gulp is silent, gulp-hub is also silent.

Thank you very much for your work.